### PR TITLE
fix: unreferenced variables

### DIFF
--- a/src/pyramid_elasticapm/__init__.py
+++ b/src/pyramid_elasticapm/__init__.py
@@ -67,6 +67,8 @@ class TweenFactory:
 
     def __call__(self, request):
         self.client.begin_transaction('request')
+        transaction_result = ""
+        response = None
         try:
             response = self.handler(request)
             transaction_result = response.status[0] + 'xx'
@@ -109,7 +111,7 @@ class TweenFactory:
         # remove Cookie header since the same data is in
         # request["cookies"] as well
         data['headers'].pop('Cookie', None)
-        if response.status_code >= 400:
+        if response is not None and response.status_code >= 400:
             data['body'] = request.body
             data['response_body'] = response.body
         return data


### PR DESCRIPTION
Fixes a `NameError("free variable 'response' referenced before assignment in enclosing scope")` error