### PR TITLE
fix: catch error adding user_id context

### DIFF
--- a/src/pyramid_elasticapm/__init__.py
+++ b/src/pyramid_elasticapm/__init__.py
@@ -93,9 +93,14 @@ class TweenFactory:
                 lambda: self.get_data_from_request(request, response),
                 'request',
             )
-            elasticapm.set_user_context(
-                user_id=request.authenticated_userid,
-            )
+            try:
+                elasticapm.set_user_context(
+                    user_id=request.authenticated_userid,
+                )
+            except Exception:
+                # getting authenticated_userid may fail. .e.g decoding an auth
+                # JWT.
+                pass
             self.client.end_transaction(transaction_name, transaction_result)
 
     def get_data_from_request(self, request, response):


### PR DESCRIPTION
Should allow our normal logging to continue working and log what it normally does...

Not tested.

Thoughts?